### PR TITLE
Add .gitattributes to ignore HTML in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-documentation


### PR DESCRIPTION
Adding .gitattributes to ignore HTML in language stats in our repository